### PR TITLE
Removed E_STRICT warning from GameServer.php for use of is_a() in php version 5.0 to 5.2

### DIFF
--- a/lib/steam/servers/GameServer.php
+++ b/lib/steam/servers/GameServer.php
@@ -313,7 +313,7 @@ abstract class GameServer extends Server {
             throw new SteamCondenserException('Response of type ' . get_class($responsePacket) . ' cannot be handled by this method.');
         }
 
-        if(!is_a($responsePacket, $expectedResponse)) {
+        if(!($responsePacket instanceof $expectedResponse)) {
             trigger_error("Expected {$expectedResponse}, got " . get_class($responsePacket) . '.');
             if($repeatOnFailure) {
                 $this->handleResponseForRequest($requestType, false);


### PR DESCRIPTION
Using php versions 5.0-5.2 results in a e_strict warning since is_a was deprecated just a change to remove the.

Kinda got annoyed by the error showing so to remove it, updated it.
