### PR TITLE
rconAuth endless loop

### DIFF
--- a/lib/steam/servers/SourceServer.php
+++ b/lib/steam/servers/SourceServer.php
@@ -92,17 +92,23 @@ class SourceServer extends GameServer {
      * Authenticates the connection for RCON communication with the server
      *
      * @param string $password The RCON password of the server
+     * @param int    $retry    Count of auto retry (Default: 3) - disable it with 0
      * @return bool whether authentication was successful
      * @see rconExec()
      * @throws SteamCondenserException if a problem occurs while parsing the
      *         reply
      * @throws TimeoutException if the request times out
      */
-    public function rconAuth($password) {
+    public function rconAuth($password, $retry = 3) {
         $this->rconRequestId = $this->generateRconRequestId();
 
         $this->rconSocket->send(new RCONAuthRequest($this->rconRequestId, $password));
         if ($this->rconSocket->getReply() == null) {
+            for($i = $retry; $i > 0; --$i) {
+                if ($this->rconAuth($password, 0)) {
+                    return true;
+                }
+            }
             return false;
         }
         $reply = $this->rconSocket->getReply();


### PR DESCRIPTION
Hey,

Maybe I found a endless loop in rconAuth method at SourceServer class. Because for example, if the rcon is wrong, and the IP is banned on the server, the server don't response anymore and the rconAuth method retry endless. Can you submit my pull request?
