### PR TITLE
SteamID to WebAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 thumbs.db
+
+# Composer ignores
+/vendor/*
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Miscellaneous unimportant OS files.
 .DS_Store
 thumbs.db
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+Contribution Guidelines
+=======================
+
+First of all, each single contribution is appreciated, whether a typo fix,
+improved documentation, a fixed bug or a whole new feature.
+
+## Making your changes
+
+ 1. Fork the repository on GitHub
+ 2. Create a topic branch with a descriptive name, e.g. `fix-issue-123` or
+    `feature-x`
+ 3. Make your modifications, complying with the
+    [code conventions](#code-conventions)
+ 4. Commit small logical changes, each with a descriptive commit message. Please
+    don't mix unrelated changes in a single commit.
+
+## Commit messages
+
+Please format your commit messages as follows:
+
+    Short summary of the change (up to 50 characters)
+
+    Optionally add a more extensive description of your change after a
+    blank line. Wrap the lines in this and the following paragraphs after
+    72 characters.
+
+## Submitting your changes
+
+ 1. Push your changes to a topic branch in your fork of the repository.
+ 2. [Submit a pull request][pr] to the original repository.
+    Describe your changes as short as possible, but as detailed as needed for
+    others to get an overview of your modifications.
+ 3. *Optionally*, [open an issue][issue] in the meta-repository if your change
+    might be relevant to other implementations of Steam Condenser. Please add a
+    link to your pull request.
+
+## Code conventions
+
+ * White spaces:
+   * Indent using 4 spaces
+   * Line endings must be line feeds (\n)
+   * Add a newline at end of file
+ * Name conventions:
+   * *UpperCamelCase* for classes
+   * *lowerCamelCase* for fields, methods and variables
+   * *UPPERCASE* for constants
+
+## Further information
+
+ * [General GitHub documentation][gh-help]
+ * [GitHub pull request documentation][gh-pr]
+ * [Google group][mail]
+ * \#steam-condenser on freenode.net
+
+ [gh-help]: https://help.github.com
+ [gh-pr]:   https://help.github.com/send-pull-requests
+ [issue]:   https://github.com/koraktor/steam-condenser/issues/new
+ [mail]:    https://groups.google.com/group/steam-condenser
+ [pr]:      https://github.com/koraktor/steam-condenser-php/pull/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ improved documentation, a fixed bug or a whole new feature.
     `feature-x`
  3. Make your modifications, complying with the
     [code conventions](#code-conventions)
- 4. Commit small logical changes, each with a descriptive commit message. Please
-    don't mix unrelated changes in a single commit.
+ 4. Commit small logical changes, each with a descriptive commit message.
+    Please don't mix unrelated changes in a single commit.
 
 ## Commit messages
 
@@ -41,9 +41,9 @@ Please format your commit messages as follows:
    * Line endings must be line feeds (\n)
    * Add a newline at end of file
  * Name conventions:
-   * *UpperCamelCase* for classes
-   * *lowerCamelCase* for fields, methods and variables
-   * *UPPERCASE* for constants
+   * `UpperCamelCase` for classes
+   * `lowerCamelCase` for fields, methods and variables
+   * `UPPER_CASE` for constants
 
 ## Further information
 

--- a/README.md
+++ b/README.md
@@ -40,5 +40,6 @@ included LICENSE file.
 * [Google group](http://groups.google.com/group/steam-condenser)
 * [Ohloh profile](http://www.ohloh.net/projects/steam-condenser)
 
-Follow Steam Condenser on Twitter
-[@steamcondenser](http://twitter.com/steamcondenser).
+Follow Steam Condenser on Google Plus+ via
+[+Steam Condenser](https://plus.google.com/b/109400543549250623875/109400543549250623875)
+or on Twitter via [@steamcondenser](https://twitter.com/steamcondenser).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ included LICENSE file.
 
 ## See Also
 
-* [Steam Condenser home](https://koraktor.de/steam-condenser)
+* [Steam Condenser home](http://koraktor.de/steam-condenser)
 * [GitHub project page](https://github.com/koraktor/steam-condenser)
 * [Wiki](https://github.com/koraktor/steam-condenser/wiki)
 * [Google group](http://groups.google.com/group/steam-condenser)

--- a/lib/exceptions/SocketException.php
+++ b/lib/exceptions/SocketException.php
@@ -30,12 +30,13 @@ class SocketException extends SteamCondenserException {
      * extension or with the given message.
      *
      * @param int|string $errorCode The error code or message
-     * @see socket_lasterror()s
+     * @see socket_lasterror()
      * @see socket_strerror()
      */
     public function __construct($errorCode) {
         if (is_string($errorCode)) {
             $errorMessage = $errorCode;
+            $errorCode = null;
         } else {
             $this->errorCode = $errorCode;
             $errorMessage = socket_strerror($errorCode) . " (Code: $errorCode)";

--- a/lib/exceptions/WebApiException.php
+++ b/lib/exceptions/WebApiException.php
@@ -76,7 +76,7 @@ class WebApiException extends SteamCondenserException {
                 $message = 'Your Web API request has been rejected. You most likely did not specify a valid Web API key.';
                 break;
             default:
-                $message = 'An unexpected error occured while executing a Web API request.';
+                $message = 'An unexpected error occurred while executing a Web API request.';
         }
 
         parent::__construct($message);

--- a/lib/steam/community/GameStats.php
+++ b/lib/steam/community/GameStats.php
@@ -93,7 +93,7 @@ class GameStats extends XMLData {
     }
 
     /**
-     * Returns the base Steam Communtiy URL for the given player and game IDs
+     * Returns the base Steam Community URL for the given player and game IDs
      *
      * @param string $userId The 64bit SteamID or custom URL of the user
      * @param mixed $gameId The application ID or short name of the game
@@ -195,7 +195,7 @@ class GameStats extends XMLData {
     }
 
     /**
-     * Returns the base Steam Communtiy URL for the stats contained in this
+     * Returns the base Steam Community URL for the stats contained in this
      * object
      *
      * @return string The base URL used for queries on these stats

--- a/lib/steam/community/SteamGame.php
+++ b/lib/steam/community/SteamGame.php
@@ -230,8 +230,7 @@ class SteamGame {
     /**
      * Returns the schema of this game
      *
-     * @return structure
-     *   The schema for the game.
+     * @return stdClass The schema for the game.
      */
     public function getSchemaForGame() {
         if ( empty($this->schema) ) {

--- a/lib/steam/community/SteamGame.php
+++ b/lib/steam/community/SteamGame.php
@@ -228,6 +228,23 @@ class SteamGame {
     }
 
     /**
+     * Returns the schema of this game
+     *
+     * @return structure
+     *   The schema for the game.
+     */
+    public function getSchemaForGame() {
+        if ( empty($this->schema) ) {
+          $params = array('appid' => $this->appId);
+          $result = WebApi::getJSON('ISteamUserStats', 'GetSchemaForGame', 2, $params);
+          $result = json_decode($result);
+          $this->schema = $result->game;
+        }
+        
+        return $this->schema;
+    }
+
+    /**
      * Returns the short name of this game (also known as "friendly name")
      *
      * @return string|null

--- a/lib/steam/community/SteamId.php
+++ b/lib/steam/community/SteamId.php
@@ -253,13 +253,6 @@ class SteamId extends XMLData {
         
         $profile = $resultSummaries->response->players[0];
         $profileBans = $resultBans->players[0];
-        if ( true ) {
-          print("<pre>");
-          var_dump($profile);
-          print("</pre><hr /><pre>");
-          var_dump($profileBans);
-          print("</pre>");
-        }
 
         if(!empty($profile->error)) {
             throw new SteamCondenserException((string) $profile->error);

--- a/lib/steam/community/SteamId.php
+++ b/lib/steam/community/SteamId.php
@@ -58,12 +58,12 @@ class SteamId extends XMLData {
     /**
      * @var stdClass
      */
-    private $GetPlayerSummaries;
+    private $getPlayerSummaries;
 
     /**
      * @var stdClass
      */
-    private $GetPlayerBans;
+    private $getPlayerBans;
 
     /**
      * Returns whether the requested Steam ID is already cached
@@ -268,8 +268,8 @@ class SteamId extends XMLData {
         $proflieGroups = $resultGroups->response;
 
         // Raw structure dump
-        $this->GetPlayerSummaries = $profile;
-        $this->GetPlayerBans = $profileBans;
+        $this->getPlayerSummaries = $profile;
+        $this->getPlayerBans = $profileBans;
         //$this->GetUserGroupList = $proflieGroups;
 
         if(!empty($profile->mostPlayedGames)) {
@@ -380,13 +380,13 @@ class SteamId extends XMLData {
       $returnImage = null;
       switch (strtolower($size)) {
         case "full":
-          $returnImage = $this->GetPlayerSummaries->avatarfull;
+          $returnImage = $this->getPlayerSummaries->avatarfull;
           break;
         case "medium":
-          $returnImage = $this->GetPlayerSummaries->avatarmedium;
+          $returnImage = $this->getPlayerSummaries->avatarmedium;
           break;
         default:
-          $returnImage = $this->GetPlayerSummaries->avatar;
+          $returnImage = $this->getPlayerSummaries->avatar;
       }
       return $returnImage;
     }
@@ -399,10 +399,10 @@ class SteamId extends XMLData {
      * @return string The base URL for this SteamID
      */
     public function getBaseUrl() {
-        if(empty($this->GetPlayerSummaries->profileurl)) {
+        if(empty($this->getPlayerSummaries->profileurl)) {
             return "http://steamcommunity.com/profiles/{$this->steamId64}";
         } else {
-            return $this->GetPlayerSummaries->profileurl;
+            return $this->getPlayerSummaries->profileurl;
         }
     }
 
@@ -418,7 +418,7 @@ class SteamId extends XMLData {
      * @return string The custom URL of this Steam ID
      */
     public function getCustomUrl() {
-        return $this->GetPlayerSummaries->profileurl;
+        return $this->getPlayerSummaries->profileurl;
     }
 
     /**
@@ -452,7 +452,7 @@ class SteamId extends XMLData {
      * @return string The URL of the full-sized avatar
      */
     public function getFullAvatarUrl() {
-        return $this->GetPlayerSummaries->avatarfull;
+        return $this->getPlayerSummaries->avatarfull;
     }
 
     /**
@@ -503,7 +503,7 @@ class SteamId extends XMLData {
      * @return string The URL of the icon-sized avatar
      */
     public function getIconAvatarUrl() {
-        return $this->GetPlayerSummaries->avatar;
+        return $this->getPlayerSummaries->avatar;
     }
 
     /**
@@ -527,7 +527,7 @@ class SteamId extends XMLData {
      * @return string The URL of the medium-sized avatar
      */
     public function getMediumAvatarUrl() {
-        return $this->GetPlayerSummaries->avatarmedium;
+        return $this->getPlayerSummaries->avatarmedium;
     }
 
     /**
@@ -536,7 +536,7 @@ class SteamId extends XMLData {
      * @return string The Steam nickname of the user
      */
     public function getNickname() {
-        return $this->GetPlayerSummaries->personaname;
+        return $this->getPlayerSummaries->personaname;
     }
 
     /**
@@ -582,7 +582,7 @@ class SteamId extends XMLData {
      * @return string This user's trading ban state
      */
     public function getTradeBanState() {
-        return $this->GetPlayerBans->EconomyBan;
+        return $this->getPlayerBans->EconomyBan;
     }
 
     /**
@@ -591,7 +591,7 @@ class SteamId extends XMLData {
      * @return bool <var>true</var> if the user has been banned by VAC
      */
     public function isBanned() {
-        return $this->GetPlayerBans->VACBanned;
+        return $this->getPlayerBans->VACBanned;
     }
 
     /**
@@ -600,7 +600,7 @@ class SteamId extends XMLData {
      * @return bool <var>true</var> if the user has been banned by Community
      */
     public function isCommunityBanned() {
-        return $this->GetPlayerBans->CommunityBanned;
+        return $this->getPlayerBans->CommunityBanned;
     }
 
     /**
@@ -619,7 +619,7 @@ class SteamId extends XMLData {
      * @return bool <var>true</var> if the user is in-game
      */
     public function isInGame() {
-        return (bool)!empty($this->GetPlayerSummaries->gameid);
+        return (bool)!empty($this->getPlayerSummaries->gameid);
     }
 
     /**
@@ -638,7 +638,7 @@ class SteamId extends XMLData {
      * @return bool <var>true</var> if the user is online
      */
     public function isOnline() {
-        return ($this->GetPlayerSummaries->personastate > 0);
+        return ($this->getPlayerSummaries->personastate > 0);
     }
 
     /**
@@ -647,7 +647,7 @@ class SteamId extends XMLData {
      * @return bool <var>true</var> if this Steam ID is public
      */
     public function isPublic() {
-        return ($this->GetPlayerSummaries->communityvisibilitystate == 5);
+        return ($this->getPlayerSummaries->communityvisibilitystate == 5);
     }
 
 }

--- a/lib/steam/community/SteamId.php
+++ b/lib/steam/community/SteamId.php
@@ -237,7 +237,7 @@ class SteamId extends XMLData {
     }
 
     /**
-     * Fetches data from the Steam Community by querying the XML version of the
+     * Fetches data from the Steam Community by querying the WebAPI version of the
      * profile specified by the ID of this Steam ID
      *
      * @throws SteamCondenserException if the Steam ID data is not available,

--- a/lib/steam/community/SteamId.php
+++ b/lib/steam/community/SteamId.php
@@ -263,14 +263,12 @@ class SteamId extends XMLData {
         $resultBans = json_decode($jsonBans);
         $resultGroups = json_decode($jsonGroups);
         
-        
         $profileBans = $resultBans->players[0];
         $proflieGroups = $resultGroups->response;
 
         // Raw structure dump
         $this->getPlayerSummaries = $profile;
         $this->getPlayerBans = $profileBans;
-        //$this->GetUserGroupList = $proflieGroups;
 
         if(!empty($profile->mostPlayedGames)) {
             foreach($profile->mostPlayedGames->mostPlayedGame as $mostPlayedGame) {
@@ -280,7 +278,7 @@ class SteamId extends XMLData {
 
         if(!empty($proflieGroups->groups)) {
             foreach($proflieGroups->groups as $group) {
-                $this->groups[] = SteamGroup::create((string) $group->gid, false);
+                $this->getUserGroupList[$group->gid] = SteamGroup::create((string) $group->gid, false);
             }
         }
 

--- a/lib/steam/community/SteamId.php
+++ b/lib/steam/community/SteamId.php
@@ -245,14 +245,10 @@ class SteamId extends XMLData {
      */
     public function fetchData() {
         
-        $params = array('steamids' => $this->steamId64);
+        $params = array('steamids' => $this->steamId64, 'steamid' => $this->steamId64);
         $jsonSummaries = WebApi::getJSON('ISteamUser', 'GetPlayerSummaries', 2, $params);
-        $jsonBans = WebApi::getJSON('ISteamUser', 'GetPlayerBans', 1, $params);
         $resultSummaries = json_decode($jsonSummaries);
-        $resultBans = json_decode($jsonBans);
-        
         $profile = $resultSummaries->response->players[0];
-        $profileBans = $resultBans->players[0];
 
         if(!empty($profile->error)) {
             throw new SteamCondenserException((string) $profile->error);
@@ -262,9 +258,19 @@ class SteamId extends XMLData {
             throw new SteamCondenserException((string) $profile->privacyMessage);
         }
         
+        $jsonBans = WebApi::getJSON('ISteamUser', 'GetPlayerBans', 1, $params);
+        $jsonGroups = WebApi::getJSON('ISteamUser', 'GetUserGroupList', 1, $params);
+        $resultBans = json_decode($jsonBans);
+        $resultGroups = json_decode($jsonGroups);
+        
+        
+        $profileBans = $resultBans->players[0];
+        $proflieGroups = $resultGroups->response;
+
         // Raw structure dump
         $this->GetPlayerSummaries = $profile;
         $this->GetPlayerBans = $profileBans;
+        //$this->GetUserGroupList = $proflieGroups;
 
         if(!empty($profile->mostPlayedGames)) {
             foreach($profile->mostPlayedGames->mostPlayedGame as $mostPlayedGame) {
@@ -272,9 +278,9 @@ class SteamId extends XMLData {
             }
         }
 
-        if(!empty($profile->groups)) {
-            foreach($profile->groups->group as $group) {
-                $this->groups[] = SteamGroup::create((string) $group->groupID64, false);
+        if(!empty($proflieGroups->groups)) {
+            foreach($proflieGroups->groups as $group) {
+                $this->groups[] = SteamGroup::create((string) $group->gid, false);
             }
         }
 

--- a/lib/steam/community/WebApi.php
+++ b/lib/steam/community/WebApi.php
@@ -179,7 +179,7 @@ class WebApi {
      */
     protected function _load($format, $interface, $method, $version = 1, $params = null) {
         $version = str_pad($version, 4, '0', STR_PAD_LEFT);
-        $url = "http://api.steampowered.com/$interface/$method/v$version/";
+        $url = "https://api.steampowered.com/$interface/$method/v$version/";
 
         $params['format'] = $format;
         $params['key']    = self::$apiKey;

--- a/lib/steam/community/WebApi.php
+++ b/lib/steam/community/WebApi.php
@@ -3,7 +3,7 @@
  * This code is free software; you can redistribute it and/or modify it under
  * the terms of the new BSD License.
  *
- * Copyright (c) 2010-2012, Sebastian Staudt
+ * Copyright (c) 2010-2013, Sebastian Staudt
  *
  * @license http://www.opensource.org/licenses/bsd-license.php New BSD License
  */
@@ -30,6 +30,11 @@ class WebApi {
      * @var WebApi
      */
     protected static $instance = null;
+
+    /**
+     * @var bool
+     */
+    protected static $secure = true;
 
     /**
      * Returns the Steam Web API key
@@ -87,6 +92,15 @@ class WebApi {
      */
     public static function load($format, $interface, $method, $version = 1, $params = null) {
         return self::instance()->_load($format, $interface, $method, $version, $params);
+    }
+
+    /**
+     * Sets whether HTTPS should be used for the communication with the Web API
+     *
+     * @param bool $secure Whether to use HTTPS
+     */
+    public static function setSecure($secure) {
+        self::$secure = $secure;
     }
 
     /**
@@ -179,7 +193,8 @@ class WebApi {
      */
     protected function _load($format, $interface, $method, $version = 1, $params = null) {
         $version = str_pad($version, 4, '0', STR_PAD_LEFT);
-        $url = "https://api.steampowered.com/$interface/$method/v$version/";
+        $protocol = (self::$secure) ? 'https' : 'http';
+        $url = "$protocol://api.steampowered.com/$interface/$method/v$version/";
 
         $params['format'] = $format;
         $params['key']    = self::$apiKey;

--- a/tests/steam/community/WebApiTest.php
+++ b/tests/steam/community/WebApiTest.php
@@ -64,8 +64,18 @@ class WebApiTest extends PHPUnit_Framework_TestCase {
         WebApi::getJSONData('interface', 'method', 2, array('test' => 'param'));
     }
 
-
     public function testLoad() {
+        $data = 'data';
+        $webApi = $this->getMockBuilder('WebApi')->setMethods(array('request'))->disableOriginalConstructor()->getMock();
+        $webApi->expects($this->once())->method('request')->with('https://api.steampowered.com/interface/method/v0002/?test=param&format=json&key=0123456789ABCDEF0123456789ABCDEF')->will($this->returnValue($data));
+        $this->instance->setValue($webApi);
+
+        $this->assertEquals('data', WebApi::load('json', 'interface', 'method', 2, array('test' => 'param')));
+    }
+
+    public function testLoadInsecure() {
+        WebApi::setSecure(false);
+
         $data = 'data';
         $webApi = $this->getMockBuilder('WebApi')->setMethods(array('request'))->disableOriginalConstructor()->getMock();
         $webApi->expects($this->once())->method('request')->with('http://api.steampowered.com/interface/method/v0002/?test=param&format=json&key=0123456789ABCDEF0123456789ABCDEF')->will($this->returnValue($data));


### PR DESCRIPTION
Using WebAPI for almost everything in SteamAPI!
- Moved to HTTPS. Things are a bit more secure this way.
- Changed SteamID structure in favor of matching to WebAPI's data
  structure.
- User Bans info implimented as SteamID->GetPlayerBans structure.
- Player data implimented as SteamID->GetPlayerSummeries structure
- New unified function getAvatarUrl() for profile images (old ones
  still exist).
- NEW isCommunityBanned() function to return Community ban status.
- Friends using WebAPI. However, strcture slightly changed.
- Some spelling corrections.
