### PR TITLE
Quick fix to handle 503 from Steam Servers

### DIFF
--- a/lib/steam/community/XMLData.php
+++ b/lib/steam/community/XMLData.php
@@ -28,8 +28,14 @@ abstract class XMLData {
      * @throws SteamCondenserException if the data cannot be parsed
      */
     protected function getData($url) {
+        
+        if( ! $xml = @file_get_contents($url) ) {
+		    $errorMessage = "An error occurred when retrieving XML from the Steam server . HTTP Response: " .  $http_response_header[0];
+		    throw new SteamCondenserException($errorMessage, 0);
+	    }
+		
         try {
-            return @new SimpleXMLElement($url, 0, true);
+            return @new SimpleXMLElement($xml);
         } catch (Exception $e) {
             $errorMessage = "XML could not be parsed: " . $e->getMessage();
             if ((float) phpversion() < 5.3) {


### PR DESCRIPTION
The Steam servers are sometimes busy when not using the Steam API. In the case they are, it throws back a 503 and the response is not XML.

Instead of showing "XML could not be parsed", this update shows that the HTTP status is a 503 (or whatever it might be), being more helpful for the user..

Not the best solution, but it seems to be working fine for my purposes.
