### PR TITLE
Fix typo from refactoring SteamGroups and SteamIds - SteamId has no fetc...

### DIFF
--- a/lib/SteamCondenser/Community/SteamId.php
+++ b/lib/SteamCondenser/Community/SteamId.php
@@ -156,7 +156,7 @@ class SteamId extends XMLData {
         if(self::isCached($id) && !$bypassCache) {
             $steamId = self::$steamIds[$id];
             if($fetch && !$steamId->isFetched()) {
-                $steamId->fetchMembers();
+                $steamId->fetchData();
             }
 
             return $steamId;


### PR DESCRIPTION
Looks like this was accidentally committed in bb4bb6be3da7995dceb3dd696430b3112356822d
