### PR TITLE
Fix SteamId missing fetchMembers method

### DIFF
--- a/lib/steam/community/SteamId.php
+++ b/lib/steam/community/SteamId.php
@@ -158,7 +158,7 @@ class SteamId extends XMLData {
         if(self::isCached($id) && !$bypassCache) {
             $steamId = self::$steamIds[$id];
             if($fetch && !$steamId->isFetched()) {
-                $steamId->fetchMembers();
+                $steamId->fetchData();
             }
 
             return $steamId;


### PR DESCRIPTION
This bug was introduced by refactoring SteamId caching in
bb4bb6be3da7995dceb3dd696430b3112356822d.
