### PR TITLE
Fix for undefined variable

### DIFF
--- a/lib/SteamCondenser/Servers/Packets/S2AINFODETAILEDPacket.php
+++ b/lib/SteamCondenser/Servers/Packets/S2AINFODETAILEDPacket.php
@@ -45,7 +45,7 @@ class S2AINFODETAILEDPacket extends S2AINFOBasePacket {
         $this->info['passwordProtected'] = $this->contentData->getByte() == 1;
         $this->info['isMod'] = $this->contentData->getByte() == 1;
 
-        if($this->isMod) {
+        if($this->info['isMod']) {
             $this->info['modInfo']['urlInfo'] = $this->contentData->getString();
             $this->info['modInfo']['urlDl'] = $this->contentData->getString();
             $this->contentData->getByte();


### PR DESCRIPTION
We're triyng to access undefined variable
```php
$this->isMod
```
But should look for **isMod** in **$this->info** array
```php
$this->info['isMod']
```