### PR TITLE
 Fix for undefined variable

### DIFF
--- a/lib/steam/packets/S2A_INFO_DETAILED_Packet.php
+++ b/lib/steam/packets/S2A_INFO_DETAILED_Packet.php
@@ -45,7 +45,7 @@ class S2A_INFO_DETAILED_Packet extends S2A_INFO_BasePacket {
         $this->info['passwordProtected'] = $this->contentData->getByte() == 1;
         $this->info['isMod'] = $this->contentData->getByte() == 1;
 
-        if($this->isMod) {
+        if($this->info['isMod']) {
             $this->info['modInfo']['urlInfo'] = $this->contentData->getString();
             $this->info['modInfo']['urlDl'] = $this->contentData->getString();
             $this->contentData->getByte();


### PR DESCRIPTION


We're triyng to access undefined variable

```php
$this->isMod
```

But should look for isMod in $this->info array

```php
$this->info['isMod']
```
