### PR TITLE
Monolog 2.x compatabiliy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "koraktor/steam-condenser",
-    "version": "1.3.11",
+    "version": "1.3.10",
     "description": "The Steam Condenser is a library for querying the Steam Community, Source and GoldSrc game servers",
     "keywords": [ "steam", "query", "source", "goldsrc", "community", "webapi" ],
     "homepage": "http://koraktor.de/steam-condenser",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "koraktor/steam-condenser",
-    "version": "1.3.10",
+    "version": "1.3.11",
     "description": "The Steam Condenser is a library for querying the Steam Community, Source and GoldSrc game servers",
     "keywords": [ "steam", "query", "source", "goldsrc", "community", "webapi" ],
     "homepage": "http://koraktor.de/steam-condenser",
@@ -18,11 +18,10 @@
         "wiki": "https://github.com/koraktor/steam-condenser/wiki"
     },
     "require": {
-        "php": ">=5.4.0",
-        "monolog/monolog": "~1.10"
+        "php": "^7.2",
+        "monolog/monolog": "^2.0"
     },
     "require-dev": {
-        "phpdocumentor/phpdocumentor": "~2.6.1",
         "phpunit/phpunit": "~4.1.3"
     },
     "autoload": {

--- a/lib/SteamCondenser.php
+++ b/lib/SteamCondenser.php
@@ -24,7 +24,5 @@ const VERSION = '1.3.10';
  * @return Logger The requested Monolog logger
  */
 function getLogger($name) {
-    $logger = new Logger($name);
-    $logger->pushHandler(new StreamHandler("php://stdout"));
-    return $logger;
+    return new Logger($name);
 }

--- a/lib/SteamCondenser.php
+++ b/lib/SteamCondenser.php
@@ -15,7 +15,7 @@ namespace SteamCondenser;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
-const VERSION = '1.3.11';
+const VERSION = '1.3.10';
 
 /**
  * Returns a Monolog logger with the given name

--- a/lib/SteamCondenser.php
+++ b/lib/SteamCondenser.php
@@ -12,9 +12,10 @@
 
 namespace SteamCondenser;
 
+use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
-const VERSION = '1.3.9';
+const VERSION = '1.3.11';
 
 /**
  * Returns a Monolog logger with the given name
@@ -23,5 +24,7 @@ const VERSION = '1.3.9';
  * @return Logger The requested Monolog logger
  */
 function getLogger($name) {
-    return new Logger($name);
+    $logger = new Logger($name);
+    $logger->pushHandler(new StreamHandler("php://stdout"));
+    return $logger;
 }


### PR DESCRIPTION
New Requirement: PHP 7.2+

This should fix https://github.com/koraktor/steam-condenser/issues/329

Testing output seemed to be identical to the current branch

One caveat, the default handler right now only prints to STDOUT, i'm not entirely sure if that was the configuration on the original, but it's what it seemed to be, if you want to log to STDERR, or a log file, or something else, just let me know, or of course feel free to edit the PR

Thanks!

