### PR TITLE
Resolves Laravel Error: Class UDPSocket cannot extend final class Socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ included LICENSE file.
 Follow Steam Condenser on Google Plus+ via
 [+Steam Condenser](https://plus.google.com/b/109400543549250623875/109400543549250623875)
 or on Twitter via [@steamcondenser](https://twitter.com/steamcondenser).
+
+To get this working in Laravel 10 and php 8: Change two entries in the composer.json file, with these version numbers:
+        "monolog/monolog": "~3.5"
+and
+        "phpunit/phpunit": "^10.1"
+        

--- a/lib/SteamCondenser/Socket.php
+++ b/lib/SteamCondenser/Socket.php
@@ -21,7 +21,7 @@ use SteamCondenser\Exceptions\SocketException;
  * @author  Sebastian Staudt
  * @package steam-condenser
  */
-abstract class Socket {
+abstract class scSocket {
 
     /**
      * The IP address the socket is connected to

--- a/lib/SteamCondenser/TCPSocket.php
+++ b/lib/SteamCondenser/TCPSocket.php
@@ -20,7 +20,7 @@ use SteamCondenser\Exceptions\SocketException;
  * @author  Sebastian Staudt
  * @package steam-condenser
  */
-class TCPSocket extends Socket {
+class TCPSocket extends scSocket {
 
     /**
      * Connects the TCP socket to the host with the given IP address and port

--- a/lib/SteamCondenser/UDPSocket.php
+++ b/lib/SteamCondenser/UDPSocket.php
@@ -20,7 +20,7 @@ use SteamCondenser\Exceptions\SocketException;
  * @author  Sebastian Staudt
  * @package steam-condenser
  */
-class UDPSocket extends Socket {
+class UDPSocket extends scSocket {
 
     /**
      * Connects the UDP socket to the host with the given IP address and port


### PR DESCRIPTION
I imported Condenser into a Laravel Framework 10 project and I got the error "Class UDPSocket cannot extend final class Socket". I troubleshooted it for a few hours and then realized that it might be a name conflict. So first I changed UDPSocket.php and changed:
class UDPSocket extends Socket {
to: class UDPSocket extends scSocket {

Then in socket.php I changed:
abstract class Socket {
to: abstract class scSocket {

Then TCPSocket.php I changed:
class TCPSocket extends Socket {
to: class TCPSocket extends scSocket {

This worked!

Also to get it working on Laravel 10 with Php 8 I also modified my composer.json with different versions:
"require": {
"monolog/monolog": "~3.5"

"require-dev": {
"phpunit/phpunit": "^10.1",

and removed phpdocumentor, not sure what that breaks?
Note, I didn't modify the composer.json file in the pull request.